### PR TITLE
fix(examples): stabilize horizontal virtual column measurement

### DIFF
--- a/packages/examples/app/js/pages/App.tsx
+++ b/packages/examples/app/js/pages/App.tsx
@@ -18,16 +18,17 @@ const colSizes = new Array(colCount).fill(colBaseSize).map(() => getRandomInt(co
 interface RowProps {
   row: Item;
   cols: readonly Item[];
+  measureColInRowIndex: number;
 }
 
-const GridRow = memo(({ row, cols }: RowProps) => {
+const GridRow = memo(({ row, cols, measureColInRowIndex }: RowProps) => {
   return (
     <div ref={row.ref} className={styles.row} style={{ height: rowSizes[row.index] }}>
       {cols.map(col => (
         <div
           key={col.index}
           className={styles.cell}
-          ref={row.index === col.index ? col.ref : void 0}
+          ref={row.index === measureColInRowIndex ? col.ref : void 0}
           style={{
             height: row.size,
             width: colSizes[col.index],
@@ -55,6 +56,7 @@ const VirtualGrid = () => {
     size: colBaseSize,
     viewport: () => viewportRef.current
   });
+  const measureColInRowIndex = rows[0]?.index ?? 0;
 
   const onScrollToRow = useCallback(() => {
     scrollToRow({
@@ -83,7 +85,7 @@ const VirtualGrid = () => {
             }}
           >
             {rows.map((row: Item) => (
-              <GridRow key={row.index} row={row} cols={cols} />
+              <GridRow key={row.index} row={row} cols={cols} measureColInRowIndex={measureColInRowIndex} />
             ))}
           </div>
         </div>


### PR DESCRIPTION
### Motivation
- Horizontal scrolling in the examples grid could "jump" because column measurement `ref` was only attached on the diagonal (`row.index === col.index`), so visible columns were not measured consistently as rows changed. 
- The goal is to attach column measurement to a stable, rendered row so horizontal offsets are measured consistently and stops reflowing during left/right scroll.

### Description
- Add a `measureColInRowIndex` prop to `RowProps` and `GridRow` to control which row receives the column measurement `ref` in `packages/examples/app/js/pages/App.tsx`.
- Replace the diagonal condition with `ref={row.index === measureColInRowIndex ? col.ref : void 0}` so a single stable row performs column measurement.
- Compute the anchor as `const measureColInRowIndex = rows[0]?.index ?? 0` in `VirtualGrid` and pass it into each `GridRow`.

### Testing
- Ran `pnpm build` at repository root which built `packages/core` successfully (passed). 
- Ran `pnpm -C packages/examples lint` which fails in this environment with `Cannot find module 'use-virtual'` from TypeScript resolution, which is an existing repo configuration issue and not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e11486f5b88333b5ec59ed4282a38e)